### PR TITLE
Stats, captures are functional

### DIFF
--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_10.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_10.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 5
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-4567357527413618298
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_11.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_11.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 0
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-780837148356279906
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_12.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_12.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 2
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &6964071943008774929
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_13.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_13.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 3
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-6625054697584789074
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_14.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_14.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 1
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &9127690082204998958
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_15.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_15.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 4
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-7159567102642648571
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_16.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_16.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 5
   color: 0
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-7952905922635950635
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_5.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_5.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 0
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &8212457472989042319
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_6.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_6.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 2
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-8208972209128390300
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_7.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_7.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 1
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-9061775203535583656
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_8.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_8.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 3
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-8107785197567267465
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_9.prefab
+++ b/Damas GS/Assets/Pieces/Prefabs/Heroes3_Pieces_9.prefab
@@ -98,10 +98,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b340274c41c95fe42b724f90429f9906, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  log:
+    show: 1
   type: 4
   color: 1
-  maxHealth: 0
-  defaultAttack: 0
+  maxHealth: 1
+  defaultAttack: 1
 --- !u!61 &-2055715435026205969
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Damas GS/Assets/Pieces/Stats/AttackCommand.cs
+++ b/Damas GS/Assets/Pieces/Stats/AttackCommand.cs
@@ -14,7 +14,7 @@ namespace Damas.Combat
 
         public bool WouldKill()
         {
-            return clientAttack.CurrentValue > receiverHealth.CurrentValue;
+            return clientAttack.CurrentValue >= receiverHealth.CurrentValue;
         }
 
         public void Execute()

--- a/Damas GS/Assets/Pieces/Stats/HealthStat.cs
+++ b/Damas GS/Assets/Pieces/Stats/HealthStat.cs
@@ -35,6 +35,7 @@ namespace Damas.Combat
 
             if (currentValue < 0)
             {
+                currentValue = 0;
             }
         }
 

--- a/Damas GS/Assets/dbug.cs
+++ b/Damas GS/Assets/dbug.cs
@@ -9,7 +9,7 @@ namespace Damas.Utils
         private const string tooLongMsg =
             "Message was over char limit. Truncted: ";
 
-        [SerializeField] private bool show = true;
+        [SerializeField] private bool show;
 
         private int tooLong = 500;
         private int maxReportSize = 10;
@@ -72,8 +72,8 @@ namespace Damas.Utils
         private string trim(string msg)
         {
             return isTooLong(msg)
-                ? msg
-                : (tooLong + msg)[..tooLong];
+                ? (tooLongMsg + msg)[..tooLong]
+                : msg;
         }
 
         private bool isTooLong(string msg)


### PR DESCRIPTION
## Pieces
- All have `AttackStat`
- All have `HealthStat`
- Stats are set 
    - With inspector vars
    - (i.e. `HealthStat = new HealthStat(maxHealth);`) 
    - During `Piece.OnSpawn()`
- `HealthStat.CurrentValue` is checked on `Update()`
    - If <= 0, `Piece` invokes `BeenCaptured(this)`

## `BoardManager`
- Subscribes to `Piece.OnSpawn()` of each piece that registers to the board using `BoardManager.RegisterPiece(Piece)`
- Becoming clearer that this has too many responsibilities
    - I hate to say it, but... state pattern??
- Creates `AttackCommand` using `selectedPiece.AttackStat` and `clickedPiece.HealthStat`
- If `attackCommand.WouldKill()`, then `attackCommandExecute()` and move piece, else just `attackCommand.Execute()` and `SwitchTurn()`
- `validTiles` is now a Property.
    - that returns either `GetValidMoves(selectedPiece)` or `new List<Vector2Int>` (i.e. an empty list).
    - This means that turning overlays off has to happen whenever a piece is about to be deselected OR whenever the turn is about to end.
- I think:
    - each piece should be responsible for reporting its moves to `BoardManager`, which validates them without storing them.
    - Each piece should have `Select()` and `Deselect()`, which manage the selection state of the piece, including the toggling of highlights/overlays.